### PR TITLE
Add auto-seeding for subscriber IDs

### DIFF
--- a/add-subscribers.js
+++ b/add-subscribers.js
@@ -1,0 +1,40 @@
+if (!process.env.KV_REST_API_URL && process.env.UPSTASH_REDIS_REST_URL) {
+  process.env.KV_REST_API_URL = process.env.UPSTASH_REDIS_REST_URL;
+}
+if (!process.env.KV_REST_API_TOKEN && process.env.UPSTASH_REDIS_REST_TOKEN) {
+  process.env.KV_REST_API_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN;
+}
+
+const { kv } = require('@vercel/kv');
+
+// Only attempt to seed if the KV credentials are configured. This script
+// runs during the deployment build step via `npm postinstall` so we don't
+// want it to fail the build if the environment variables are missing.
+if (!process.env.KV_REST_API_URL || !process.env.KV_REST_API_TOKEN) {
+  console.log('[add-subscribers] KV credentials not found; skipping seeding');
+  process.exit(0);
+}
+
+const SUBSCRIBERS_KEY = 'allocationSubscribers';
+const ids = [
+  '169127116732891136',
+  '178980194197962755',
+  '297784270334722059',
+  '373949108433584139',
+  '452205802405756929',
+  '534855346498437179',
+  '538208941973438475',
+  '936882956302159902',
+  '961355883298828368',
+  '1247981696951910496'
+];
+
+(async () => {
+  try {
+    await kv.sadd(SUBSCRIBERS_KEY, ...ids);
+    console.log('Added subscriber IDs to KV');
+  } catch (err) {
+    console.error('Failed to add subscribers', err);
+    process.exitCode = 1;
+  }
+})();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "my-bot",
   "version": "1.0.0",
+  "scripts": {
+    "postinstall": "node add-subscribers.js",
+    "add-subscribers": "node add-subscribers.js"
+  },
   "dependencies": {
     "discord-interactions": "^2.0.2",
     "raw-body": "^2.4.1",


### PR DESCRIPTION
## Summary
- automatically seed allocation subscriber IDs during deployment using a postinstall script
- skip the seeding script if KV credentials are missing so builds don't fail

## Testing
- `node -c add-subscribers.js`
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_688d0713df9c8326a509a21e1902cd7e